### PR TITLE
Causes ./autogen.sh to finish successfully on Mac OS X

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,6 +14,8 @@ AM_INIT_AUTOMAKE([dist-bzip2 foreign no-dependencies subdir-objects -Wall])
 
 AC_CANONICAL_HOST
 
+AC_PROG_OBJCXX
+
 AC_ARG_ENABLE(universal, dnl
 [  --disable-universal     build a universal binary on Mac OS X [default=yes]],
               universal=$enableval, universal=yes)


### PR DESCRIPTION
May subsequently need `./configure --disable-universal`
