### PR TITLE
CI: build releases for Linux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest]
+        os: [macos-latest, windows-latest, ubuntu-latest]
     steps:
     - uses: actions/checkout@v2
     - name: configure
@@ -25,6 +25,9 @@ jobs:
     - name: zip
       if: runner.os == 'macOS'
       run: zip AtomicParsleyMacOS.zip AtomicParsley
+    - name: zip
+      if: runner.os == 'Linux'
+      run: zip AtomicParsleyLinux.zip AtomicParsley
     - name: zip
       if: runner.os == 'Windows'
       run: 7z a -tzip AtomicParsleyWindows.zip Release/AtomicParsley.exe

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ setting metadata into MPEG-4 files, in particular, iTunes-style metadata.
 * Navigate to the [latest release](https://github.com/wez/atomicparsley/releases/latest)
 * Download the `AtomicParsleyWindows.zip` file and extract `AtomicParsley.exe`
 
+### Linux
+
+* Navigate to the [latest release](https://github.com/wez/atomicparsley/releases/latest)
+* Download the `AtomicParsleyLinux.zip` file and extract `AtomicParsley`
+
 ### Building from Source
 
 If you are building from source you will need `cmake` and `make`.


### PR DESCRIPTION
Building for Linux works, provide a prebuilt binary in releases.

Example: https://github.com/miraclx/atomicparsley/releases/tag/20_test_linux_release