### PR TITLE
CI: build releases for Alpine

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,12 +22,25 @@ jobs:
       run: cmake .
     - name: build
       run: cmake --build . --config Release
+    - name: build-musl
+      if: runner.os == 'Linux'
+      run: |
+        rm CMakeCache.txt
+        mv AtomicParsley AtomicParsleyLinux
+        docker run --rm -it -v "$(pwd):/mnt" -w '/mnt' alpine sh -c "\
+          apk add cmake build-base linux-headers zlib-dev && \
+          cmake . \
+          cmake --build . --config Release \
+        "
     - name: zip
       if: runner.os == 'macOS'
       run: zip AtomicParsleyMacOS.zip AtomicParsley
     - name: zip
       if: runner.os == 'Linux'
-      run: zip AtomicParsleyLinux.zip AtomicParsley
+      run: |
+        zip AtomicParsleyAlpine.zip AtomicParsley
+        mv AtomicParsleyLinux AtomicParsley
+        zip AtomicParsleyLinux.zip AtomicParsley
     - name: zip
       if: runner.os == 'Windows'
       run: 7z a -tzip AtomicParsleyWindows.zip Release/AtomicParsley.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest]
+        os: [macos-latest, windows-latest, ubuntu-latest]
     steps:
     - uses: actions/checkout@v2
     - name: configure
@@ -25,6 +25,9 @@ jobs:
     - name: zip
       if: runner.os == 'macOS'
       run: zip AtomicParsleyMacOS.zip AtomicParsley
+    - name: zip
+      if: runner.os == 'Linux'
+      run: zip AtomicParsleyLinux.zip AtomicParsley
     - name: zip
       if: runner.os == 'Windows'
       run: 7z a -tzip AtomicParsleyWindows.zip Release/AtomicParsley.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         rm CMakeCache.txt
         mv AtomicParsley AtomicParsleyLinux
-        docker run --rm -it -v "$(pwd):/mnt" -w '/mnt' alpine sh -c "\
+        docker run --rm -v "$(pwd):/mnt" -w '/mnt' alpine sh -c "\
           apk add cmake build-base linux-headers zlib-dev && \
           cmake . \
           cmake --build . --config Release \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         mv AtomicParsley AtomicParsleyLinux
         docker run --rm -v "$(pwd):/mnt" -w '/mnt' alpine sh -c "\
           apk add cmake build-base linux-headers zlib-dev && \
-          cmake . \
+          cmake . && \
           cmake --build . --config Release \
         "
     - name: zip

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ setting metadata into MPEG-4 files, in particular, iTunes-style metadata.
 * Navigate to the [latest release](https://github.com/wez/atomicparsley/releases/latest)
 * Download the `AtomicParsleyWindows.zip` file and extract `AtomicParsley.exe`
 
+### Linux
+
+* Navigate to the [latest release](https://github.com/wez/atomicparsley/releases/latest)
+* Download the `AtomicParsleyLinux.zip` file and extract `AtomicParsley`
+
 ### Building from Source
 
 If you are building from source you will need `cmake` and `make`.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ setting metadata into MPEG-4 files, in particular, iTunes-style metadata.
 * Navigate to the [latest release](https://github.com/wez/atomicparsley/releases/latest)
 * Download the `AtomicParsleyLinux.zip` file and extract `AtomicParsley`
 
+### Alpine (musl)
+
+* Navigate to the [latest release](https://github.com/wez/atomicparsley/releases/latest)
+* Download the `AtomicParsleyAlpine.zip` file and extract `AtomicParsley`
+
 ### Building from Source
 
 If you are building from source you will need `cmake` and `make`.

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ setting metadata into MPEG-4 files, in particular, iTunes-style metadata.
 * Navigate to the [latest release](https://github.com/wez/atomicparsley/releases/latest)
 * Download the `AtomicParsleyWindows.zip` file and extract `AtomicParsley.exe`
 
-### Linux
+### Linux (x86-64)
 
 * Navigate to the [latest release](https://github.com/wez/atomicparsley/releases/latest)
 * Download the `AtomicParsleyLinux.zip` file and extract `AtomicParsley`
 
-### Alpine (musl)
+### Alpine Linux (x86-64 musl libc)
 
 * Navigate to the [latest release](https://github.com/wez/atomicparsley/releases/latest)
 * Download the `AtomicParsleyAlpine.zip` file and extract `AtomicParsley`


### PR DESCRIPTION
Building for Alpine (musl) works, provide a prebuilt binary in releases.

Example: https://github.com/miraclx/atomicparsley/releases/tag/20_test_alpine_release