### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.16)
 project(AtomicParsley)
 
 if(NOT CMAKE_BUILD_TYPE)


### PR DESCRIPTION
Changed the cmake prequisite from 3.17 to 3.16 to be able to build atomicparsley on Ubuntu 20.04.2 LTS