### PR TITLE
Updated CMakeLists.txt to build on Ubuntu 18.04 LTS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.10)
 project(AtomicParsley)
 
 if(NOT CMAKE_BUILD_TYPE)
@@ -100,4 +100,4 @@ if (ASAN)
   set (CMAKE_LINKER_FLAGS_DEBUG "${CMAKE_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
 endif()
 
-install(TARGETS AtomicParsley RUNTIME)
+install(TARGETS AtomicParsley RUNTIME DESTINATION bin)


### PR DESCRIPTION
Hi,

I just updated CMakeLists.txt to able to build on Ubuntu 18.04 LTS cf. [issue 37](../issues/37).

It works :smile: : 
```bash
$ lsb_release -a
No LSB modules are available.
Ubuntu
Ubuntu 18.04.5 LTS
18.04
bionic
```

```make
 cmake . && make
-- The C compiler identification is GNU 7.5.0
-- The CXX compiler identification is GNU 7.5.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Looking for strsep
-- Looking for strsep - found
-- Looking for fseeko
-- Looking for fseeko - found
-- Found ZLIB: /usr/lib/i386-linux-gnu/libz.so (found version "1.2.11") 
-- Configuring done
-- Generating done
-- Build files have been written to: /home/sebastien/git/wez/atomicparsley
Scanning dependencies of target AtomicParsley
[  7%] Building CXX object CMakeFiles/AtomicParsley.dir/src/arrays.cpp.o
[ 15%] Building CXX object CMakeFiles/AtomicParsley.dir/src/CDtoc.cpp.o
[ 23%] Building CXX object CMakeFiles/AtomicParsley.dir/src/compress.cpp.o
[ 30%] Building CXX object CMakeFiles/AtomicParsley.dir/src/extracts.cpp.o
[ 38%] Building CXX object CMakeFiles/AtomicParsley.dir/src/iconv.cpp.o
[ 46%] Building CXX object CMakeFiles/AtomicParsley.dir/src/id3v2.cpp.o
/home/sebastien/git/wez/atomicparsley/src/extracts.cpp: In function ‘void APar_ExtractDetails(FILE*, uint8_t)’:
/home/sebastien/git/wez/atomicparsley/src/extracts.cpp:894:22: warning: argument 2 null where non-null expected [-Wnonnull]
           if (strncmp(parsedAtoms[next_atom].AtomicName,
               ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                       track_search_atom_name,
                       ~~~~~~~~~~~~~~~~~~~~~~~
                       4) == 0) {
                       ~~
In file included from /home/sebastien/git/wez/atomicparsley/src/AtomicParsley.h:52:0,
                 from /home/sebastien/git/wez/atomicparsley/src/extracts.cpp:23:
/usr/include/string.h:139:12: note: in a call to function ‘int strncmp(const char*, const char*, size_t)’ declared here
 extern int strncmp (const char *__s1, const char *__s2, size_t __n)
            ^~~~~~~
[ 53%] Building CXX object CMakeFiles/AtomicParsley.dir/src/main.cpp.o
/home/sebastien/git/wez/atomicparsley/src/id3v2.cpp: In function ‘void APar_ID3FrameAmmend(AtomicInfo*, const char*, const char*, AdjunctArgs*, uint8_t)’:
/home/sebastien/git/wez/atomicparsley/src/id3v2.cpp:2880:6: warning: ‘%u’ directive writing between 1 and 3 bytes into a region of size 2 [-Wformat-overflow=]
 void APar_ID3FrameAmmend(AtomicInfo *id32_atom,
      ^~~~~~~~~~~~~~~~~~~
/home/sebastien/git/wez/atomicparsley/src/id3v2.cpp:2880:6: note: directive argument in the range [0, 254]
In file included from /usr/include/stdio.h:862:0,
                 from /home/sebastien/git/wez/atomicparsley/src/AtomicParsley.h:50,
                 from /home/sebastien/git/wez/atomicparsley/src/id3v2.cpp:23:
/usr/include/i386-linux-gnu/bits/stdio2.h:34:43: note: ‘__builtin___sprintf_chk’ output between 2 and 4 bytes into a destination of size 2
       __bos (__s), __fmt, __va_arg_pack ());
                                           ^
[ 61%] Building CXX object CMakeFiles/AtomicParsley.dir/src/metalist.cpp.o
[ 69%] Building CXX object CMakeFiles/AtomicParsley.dir/src/parsley.cpp.o
[ 76%] Building CXX object CMakeFiles/AtomicParsley.dir/src/sha1.cpp.o
[ 84%] Building CXX object CMakeFiles/AtomicParsley.dir/src/util.cpp.o
/home/sebastien/git/wez/atomicparsley/src/parsley.cpp: In function ‘void APar_SampleTableIterator(FILE*)’:
/home/sebastien/git/wez/atomicparsley/src/parsley.cpp:1316:6: warning: ‘__builtin___sprintf_chk’ may write a terminating nul past the end of the destination [-Wformat-overflow=]
 void APar_SampleTableIterator(FILE *file) {
      ^~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/stdio.h:862:0,
                 from /home/sebastien/git/wez/atomicparsley/src/AtomicParsley.h:50,
                 from /home/sebastien/git/wez/atomicparsley/src/AtomDefs.h:23,
                 from /home/sebastien/git/wez/atomicparsley/src/parsley.cpp:30:
/usr/include/i386-linux-gnu/bits/stdio2.h:34:43: note: ‘__builtin___sprintf_chk’ output between 28 and 37 bytes into a destination of size 36
       __bos (__s), __fmt, __va_arg_pack ());
                                           ^
[ 92%] Building CXX object CMakeFiles/AtomicParsley.dir/src/uuid.cpp.o
/home/sebastien/git/wez/atomicparsley/src/parsley.cpp: In function ‘void APar_DeriveNewPath(const char*, char*, int, const char*, const char*, bool)’:
/home/sebastien/git/wez/atomicparsley/src/parsley.cpp:5555:6: warning: ‘__builtin___sprintf_chk’ may write a terminating nul past the end of the destination [-Wformat-overflow=]
 void APar_DeriveNewPath(const char *filePath,
      ^~~~~~~~~~~~~~~~~~
In file included from /usr/include/stdio.h:862:0,
                 from /home/sebastien/git/wez/atomicparsley/src/AtomicParsley.h:50,
                 from /home/sebastien/git/wez/atomicparsley/src/AtomDefs.h:23,
                 from /home/sebastien/git/wez/atomicparsley/src/parsley.cpp:30:
/usr/include/i386-linux-gnu/bits/stdio2.h:34:43: note: ‘__builtin___sprintf_chk’ output between 2 and 7 bytes into a destination of size 6
       __bos (__s), __fmt, __va_arg_pack ());
                                           ^
/home/sebastien/git/wez/atomicparsley/src/parsley.cpp: In function ‘void APar_MetadataFileDump(const char*)’:
/home/sebastien/git/wez/atomicparsley/src/parsley.cpp:5622:6: warning: ‘__builtin___sprintf_chk’ may write a terminating nul past the end of the destination [-Wformat-overflow=]
 void APar_MetadataFileDump(const char *ISObasemediafile) {
      ^~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/stdio.h:862:0,
                 from /home/sebastien/git/wez/atomicparsley/src/AtomicParsley.h:50,
                 from /home/sebastien/git/wez/atomicparsley/src/AtomDefs.h:23,
                 from /home/sebastien/git/wez/atomicparsley/src/parsley.cpp:30:
/usr/include/i386-linux-gnu/bits/stdio2.h:34:43: note: ‘__builtin___sprintf_chk’ output between 2 and 7 bytes into a destination of size 6
       __bos (__s), __fmt, __va_arg_pack ());
                                           ^
[100%] Linking CXX executable AtomicParsley
[100%] Built target AtomicParsley
```

```bash
$ sudo make install
[100%] Built target AtomicParsley
Install the project...
-- Install configuration: "Release"
-- Installing: /usr/local/bin/AtomicParsley
$ AtomicParsley -v
AtomicParsley version: 20210715.151551.0 e7ad03a341f2638c12970dff18a13e86fa57b679 (utf8)
```