### PR TITLE
Fix out of range compares on unsigned char archs (powerpc and arm)

### DIFF
--- a/src/AtomicParsley.h
+++ b/src/AtomicParsley.h
@@ -258,7 +258,7 @@ AtomicInfo *APar_UserData_atom_Init(const char *userdata_atom_name,
 
 /* ID3v2 (2.4) style metadata, non-external form */
 AtomicInfo *APar_ID32_atom_Init(const char *frameID_str,
-                                char meta_area,
+                                signed char meta_area,
                                 const char *lang_str,
                                 uint16_t id32_lang);
 

--- a/src/parsley.cpp
+++ b/src/parsley.cpp
@@ -3561,7 +3561,7 @@ AtomicInfo *APar_reverseDNS_atom_Init(const char *rDNS_atom_name,
 }
 
 AtomicInfo *APar_ID32_atom_Init(const char *frameID_str,
-                                char meta_area,
+                                signed char meta_area,
                                 const char *lang_str,
                                 uint16_t id32_lang) {
   uint8_t total_tracks = 0;


### PR DESCRIPTION
Hi,

Some architectures have unsigned char by default, notably powerpc and arm. While building atomicparsley on my powerpc box, i've got several out of range warnings.

I'm sadly not able to provide a bug reproducer, not being familiar with ID32 internals does not help much to do so indeed :)

That PR makes `meta_area` explicitly a signed char, and warnings have vanished.

```
/shm/pobj/atomicparsley-20210715/atomicparsley-20210715.151551.e7ad03a/src/parsley.cpp:3592:24: warning: result of comparison of constant -1 with expression of type 'char' is always false [-Wtautological-constant-out-of-range-compare]
  } else if (meta_area == 0 - MOVIE_LEVEL_ATOM) {
             ~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~
/shm/pobj/atomicparsley-20210715/atomicparsley-20210715.151551.e7ad03a/src/parsley.cpp:3624:24: warning: result of comparison of constant -1 with expression of type 'char' is always false [-Wtautological-constant-out-of-range-compare]
  } else if (meta_area == 0 - MOVIE_LEVEL_ATOM) {
             ~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~
/shm/pobj/atomicparsley-20210715/atomicparsley-20210715.151551.e7ad03a/src/parsley.cpp:3681:28: warning: result of comparison of constant -1 with expression of type 'char' is always false [-Wtautological-constant-out-of-range-compare]
      } else if (meta_area == 0 - MOVIE_LEVEL_ATOM) {
                 ~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~
/shm/pobj/atomicparsley-20210715/atomicparsley-20210715.151551.e7ad03a/src/parsley.cpp:3695:28: warning: result of comparison of constant -1 with expression of type 'char' is always false [-Wtautological-constant-out-of-range-compare]
      } else if (meta_area == 0 - MOVIE_LEVEL_ATOM) {
                 ~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~
/shm/pobj/atomicparsley-20210715/atomicparsley-20210715.151551.e7ad03a/src/parsley.cpp:3724:26: warning: result of comparison of constant -1 with expression of type 'char' is always false [-Wtautological-constant-out-of-range-compare]
    } else if (meta_area == 0 - MOVIE_LEVEL_ATOM) {
               ~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~
/shm/pobj/atomicparsley-20210715/atomicparsley-20210715.151551.e7ad03a/src/parsley.cpp:3757:26: warning: result of comparison of constant -1 with expression of type 'char' is always false [-Wtautological-constant-out-of-range-compare]
    } else if (meta_area == 0 - MOVIE_LEVEL_ATOM) {
```