### PR TITLE
Fix parentheses warning

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3797,9 +3797,9 @@ int real_main(int argc, char *argv[]) {
 
         formed_keyword_struct = (char *)calloc(
             1,
-            sizeof(char) * set_UTF16_text
+            sizeof(char) * (set_UTF16_text
                 ? (keyword_strlen * 4)
-                : (keyword_strlen * 2)); // *4 should carry utf16's BOM & TERM
+                : (keyword_strlen * 2))); // *4 should carry utf16's BOM & TERM
         uint32_t keyword_struct_bytes =
             APar_3GP_Keyword_atom_Format(keywords_globbed,
                                          keyword_count,


### PR DESCRIPTION
Clang 12 produces the following warning:
src/main.cpp:3801:17: warning: operator '?:' has lower precedence than '*'; '*' will be evaluated first [-Wparentheses]
                ? (keyword_strlen * 4)
                ^
src/main.cpp:3801:17: note: place parentheses around the '*' expression to silence this warning
                ? (keyword_strlen * 4)
                ^
src/main.cpp:3801:17: note: place parentheses around the '?:' expression to evaluate it first
                ? (keyword_strlen * 4)

Signed-off-by: Juhyung Park <qkrwngud825@gmail.com>