### PR TITLE
Added 32-bit Windows build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: configure
       run: cmake .
     - name: build
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: configure
       run: cmake -DASAN=on -DCMAKE_BUILD_TYPE=Debug .
     - name: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,19 @@ jobs:
         zip AtomicParsleyLinux.zip AtomicParsley
     - name: zip
       if: runner.os == 'Windows'
-      run: 7z a -tzip AtomicParsleyWindows.zip Release/AtomicParsley.exe
+      run: |
+        pushd Release
+        7z a -tzip ../AtomicParsleyWindows.zip AtomicParsley.exe
+        popd
+    - name: build-windows-x86
+      if: runner.os == 'Windows'
+      run: |
+        rm CMakeCache.txt
+        cmake -S . -B build-windows-x86 -A Win32
+        cmake --build build-windows-x86 --config Release
+        pushd build-windows-x86/Release
+        7z a -tzip ../../AtomicParsleyWindowsX86.zip AtomicParsley.exe
+        popd
     - name: "Upload to Tagged Release"
       uses: softprops/action-gh-release@v1
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: configure
       run: cmake .
     - name: build


### PR DESCRIPTION
This change retains dynamic linking of MSVC runtime library for Windows builds. If desired, I'll submit a further PR that switches to static linking. That would remove the the need for some users on older versions of Windows to install VC++ Redistributable separately.

Both CI and Release actions upgraded to use actions/checkout@v3