### PR TITLE
Attempt to fix buffer overflows with rDNS tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ CMakeFiles/
 cmake_install.cmake
 .ninja*
 *.ninja
+build/
+.vscode/

--- a/src/parsley.cpp
+++ b/src/parsley.cpp
@@ -2741,7 +2741,7 @@ APar_MetaData_atomGenre_Set
 
     genre is special in that it gets carried on 2 atoms. A standard genre (as
 listed in ID3v1GenreList) is represented as a number on a 'gnre' atom any value
-other than those, and the genre is placed as a string onto a 'ï¿½gen' atom. Only
+other than those, and the genre is placed as a string onto a '©gen' atom. Only
 one or the other can be present. So if atomPayload is a non-NULL value, first
 try and match the genre into the ID3v1GenreList standard genres. Try to remove
 the other type of genre atom, then find or create the new genre atom and put the
@@ -2751,8 +2751,8 @@ void APar_MetaData_atomGenre_Set(const char *atomPayload) {
   if (metadata_style == ITUNES_STYLE) {
     const char *standard_genre_atom = "moov.udta.meta.ilst.gnre";
     const char *std_genre_data_atom = "moov.udta.meta.ilst.gnre.data";
-    const char *custom_genre_atom = "moov.udta.meta.ilst.ï¿½gen";
-    const char *cstm_genre_data_atom = "moov.udta.meta.ilst.ï¿½gen.data";
+    const char *custom_genre_atom = "moov.udta.meta.ilst.©gen";
+    const char *cstm_genre_data_atom = "moov.udta.meta.ilst.©gen.data";
 
     if (strlen(atomPayload) == 0) {
       APar_RemoveAtom(std_genre_data_atom,
@@ -2770,7 +2770,7 @@ void APar_MetaData_atomGenre_Set(const char *atomPayload) {
       modified_atoms = true;
 
       if (genre_number != 0) {
-        // first find if a custom genre atom ("ï¿½gen") exists; erase the
+        // first find if a custom genre atom ("©gen") exists; erase the
         // custom-string genre atom in favor of the standard genre atom
 
         AtomicInfo *verboten_genre_atom =
@@ -2778,7 +2778,7 @@ void APar_MetaData_atomGenre_Set(const char *atomPayload) {
 
         if (verboten_genre_atom != NULL) {
           if (strlen(verboten_genre_atom->AtomicName) > 0) {
-            if (strncmp(verboten_genre_atom->AtomicName, "ï¿½gen", 4) == 0) {
+            if (strncmp(verboten_genre_atom->AtomicName, "©gen", 4) == 0) {
               APar_RemoveAtom(cstm_genre_data_atom, VERSIONED_ATOM, 0);
             }
           }
@@ -2835,7 +2835,7 @@ void APar_MetaData_atomLyrics_Set(const char *lyricsPath) {
     modified_atoms = true;
 
     AtomicInfo *lyricsData_atom =
-        APar_FindAtom("moov.udta.meta.ilst.ï¿½lyr.data", true, VERSIONED_ATOM, 0);
+        APar_FindAtom("moov.udta.meta.ilst.©lyr.data", true, VERSIONED_ATOM, 0);
     APar_MetaData_atom_QuickInit(
         lyricsData_atom->AtomicNumber, AtomFlags_Data_Text, 0, file_len + 1);
 

--- a/src/parsley.cpp
+++ b/src/parsley.cpp
@@ -3510,9 +3510,9 @@ AtomicInfo *APar_reverseDNS_atom_Init(const char *rDNS_atom_name,
                                                  0,
                                                  ilst_atom->AtomicLevel + 2,
                                                  rDNS_mean_atom);
-    // set atom length to 12 as it was from the beginning before applying
+    // set atom length to 16 as it was from the beginning before applying
     // https://github.com/wez/atomicparsley/issues/44
-    parsedAtoms[rDNS_name_atom].AtomicLength = 12;
+    parsedAtoms[rDNS_name_atom].AtomicLength = 16;
 
     parsedAtoms[rDNS_name_atom].ReverseDNSname =
         (char *)calloc(1, sizeof(char) * (name_len + 1));

--- a/tests/test_reverseDNS.sh
+++ b/tests/test_reverseDNS.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+cd "$(dirname "$0")" || exit
+
+# AP location
+AP=../build/AtomicParsley
+if [ ! -f "${AP}" ]; then
+  AP=./AtomicParsley
+fi
+
+# input location
+INPUT=issue-32.mp4
+
+# output location
+OUTPUT=issue-32-reverseDNS.mp4
+if [ -f "${OUTPUT}" ]; then
+  rm "${OUTPUT}"
+fi
+
+# try to add many rDNS tags from input to output
+"${AP}" "${INPUT}" \
+  --title "I Recall" \
+  --artist Cosmograf \
+  --album "Heroic Materials" \
+  --genre "Progressive Rock" \
+  --tracknum 01/10 \
+  --disk 01/01 \
+  --year 2022 \
+  --stik Normal \
+  --sortOrder albumartist Cosmograf \
+  --sortOrder artist Cosmograf \
+  --albumArtist Cosmograf \
+  --rDNSatom edc087c7-186c-411d-8285-0c3bb55aae5c "name=MusicBrainz Album Artist Id" domain=com.apple.iTunes \
+  --rDNSatom efeeb1ac-cdd8-433b-bced-aa285de34025 "name=MusicBrainz Album Id" domain=com.apple.iTunes \
+  --rDNSatom edc087c7-186c-411d-8285-0c3bb55aae5c "name=MusicBrainz Artist Id" domain=com.apple.iTunes \
+  --rDNSatom 605f8821-fd66-49c4-82dc-3563e8e6d289 "name=MusicBrainz Track Id" domain=com.apple.iTunes \
+  --rDNSatom 8b87507e-2a54-4438-baf3-046b0f099e8a "name=Acoustid Id" domain=com.apple.iTunes \
+  --rDNSatom f6a879d9-33d1-4247-8e19-426cd932b3b5 "name=MusicBrainz Release Group Id" domain=com.apple.iTunes \
+  --rDNSatom c530683b-07a2-4677-9990-6c5dac20b3f0 "name=MusicBrainz Release Track Id" domain=com.apple.iTunes \
+  --rDNSatom XW "name=MusicBrainz Album Release Country" domain=com.apple.iTunes \
+  --rDNSatom official "name=MusicBrainz Album Status" domain=com.apple.iTunes \
+  --rDNSatom album "name=MusicBrainz Album Type" domain=com.apple.iTunes \
+  --rDNSatom 0796520103412 name=BARCODE domain=com.apple.iTunes \
+  --rDNSatom "Digital Media" name=MEDIA domain=com.apple.iTunes \
+  --rDNSatom Latn name=SCRIPT domain=com.apple.iTunes \
+  --rDNSatom "-3.36 dB" name=replaygain_album_gain domain=com.apple.iTunes \
+  --rDNSatom 0.98791504 name=replaygain_album_peak domain=com.apple.iTunes \
+  --rDNSatom "-0.07 dB" name=replaygain_track_gain domain=com.apple.iTunes \
+  --rDNSatom 0.57928467 name=replaygain_track_peak domain=com.apple.iTunes \
+  --rDNSatom "89.0 dB" name=replaygain_reference_loudness domain=com.apple.iTunes \
+  -o "${OUTPUT}"
+
+# display results
+if [ -f "${OUTPUT}" ]; then
+  "${AP}" "${OUTPUT}" -T 1 -t +
+  rm "${OUTPUT}"
+  echo "OK"
+  exit 0
+else
+  echo "KO"
+  exit 1
+fi


### PR DESCRIPTION
As asked, 
I created this PR with a test_reverseDNS.sh script to test adding many rDNS tags to already provided issue-32.mp4.

Without this patch, there are still buffer overflows.
Corresponding ASAN report is already uploaded here: https://github.com/wez/atomicparsley/issues/62

