### PR TITLE
Add fallback LEADOUT_TRACK_NUMBER = 0xAA for non Win/Mac/Linux

### DIFF
--- a/src/CDtoc.cpp
+++ b/src/CDtoc.cpp
@@ -76,6 +76,8 @@ uint8_t LEADOUT_TRACK_NUMBER = CDROM_LEADOUT;
 #elif defined(_WIN32)
 uint8_t LEADOUT_TRACK_NUMBER =
     0xAA; // NOTE: for WinXP IOCTL_CDROM_READ_TOC_EX code, its 0xA2
+#else
+uint8_t LEADOUT_TRACK_NUMBER = 0xAA;
 #endif
 
 /*


### PR DESCRIPTION
(Linux and Windows also use 0xAA)

This allows atomicparsley to build on other platforms such as NetBSD and FreeBSD, without affecting any behaviour on supported platforms