### PR TITLE
chore: name releases using standard libc host triples

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,18 +34,18 @@ jobs:
         "
     - name: zip
       if: runner.os == 'macOS'
-      run: zip AtomicParsleyMacOS.zip AtomicParsley
+      run: zip AtomicParsley-x86_64-apple-darwin.zip AtomicParsley
     - name: zip
       if: runner.os == 'Linux'
       run: |
-        zip AtomicParsleyAlpine.zip AtomicParsley
+        zip AtomicParsley-x86_64-unknown-linux-musl++.zip AtomicParsley
         mv AtomicParsleyLinux AtomicParsley
-        zip AtomicParsleyLinux.zip AtomicParsley
+        zip AtomicParsley-x86_64-unknown-linux.zip AtomicParsley
     - name: zip
       if: runner.os == 'Windows'
       run: |
         pushd Release
-        7z a -tzip ../AtomicParsleyWindows.zip AtomicParsley.exe
+        7z a -tzip ../AtomicParsley-x86_64-pc-windows-msvc.zip AtomicParsley.exe
         popd
     - name: build-windows-x86
       if: runner.os == 'Windows'
@@ -54,7 +54,7 @@ jobs:
         cmake -S . -B build-windows-x86 -A Win32
         cmake --build build-windows-x86 --config Release
         pushd build-windows-x86/Release
-        7z a -tzip ../../AtomicParsleyWindowsX86.zip AtomicParsley.exe
+        7z a -tzip ../../AtomicParsley-x86-pc-windows-msvc.zip AtomicParsley.exe
         popd
     - name: "Upload to Tagged Release"
       uses: softprops/action-gh-release@v1


### PR DESCRIPTION
I'm the one of the core maintainers of [webinstall.dev](https://webinstall.dev) and I'm adding an AtomicParsley installer.

I'm submitting this change to use standard host triples for release names so that standard so that the install type can be automated by Webi and other installer and package management tools without requiring custom mappings or manual configuration.

- `AtomicParsley-x86_64-apple-darwin.zip` (Intel & M1)
- `AtomicParsley-x86_64-unknown-linux-musl++.zip` (Alpine / musl ONLY due to musl++)
- `AtomicParsley-x86_64-unknown-linux.zip` (Debian / libc only)
- `AtomicParsley-x86_64-pc-windows-msvc.zip` (Windows & Windows 11 ARM)
- `AtomicParsley-x86-pc-windows-msvc.zip` (Windows i686)

This is very common across GitHub (and other platforms) for projects that provide binary releases.

## The Host Triple Standard

Most of the common C-family / libc-compatible build tools for C, C++, Rust, GoReleaser, and Zig put host triple is format of `<cpu>-<platform>-<os>-<libc>` (technically a host quadruple I suppose).

### LLVM

- `arch` = x86_64, i386, arm, thumb, mips, etc.
- `sub` = for ex. on ARM: v5, v6m, v7a, v7m, etc.
- `vendor` = pc, apple, nvidia, ibm, etc.
- `sys` = none, linux, win32, darwin, cuda, etc.
- `env` = eabi, gnu, android, macho, elf, etc.

Source: <https://clang.llvm.org/docs/CrossCompilation.html>

### Rust

```sh
rustc --print target-list | sort -r
```

```txt
x86_64-wrs-vxworks
x86_64-uwp-windows-msvc
x86_64-uwp-windows-gnu
x86_64-unknown-uefi
x86_64-unknown-redox
x86_64-unknown-openbsd
x86_64-unknown-none-linuxkernel
x86_64-unknown-none
x86_64-unknown-netbsd
x86_64-unknown-linux-musl
x86_64-unknown-linux-gnux32
x86_64-unknown-linux-gnu
x86_64-unknown-l4re-uclibc
x86_64-unknown-illumos
x86_64-unknown-hermit
x86_64-unknown-haiku
x86_64-unknown-freebsd
x86_64-unknown-dragonfly
x86_64-sun-solaris
x86_64-pc-windows-msvc
x86_64-pc-windows-gnu
x86_64-pc-solaris
x86_64-linux-android
x86_64-fuchsia
x86_64-fortanix-unknown-sgx
x86_64-apple-tvos
x86_64-apple-ios-macabi
x86_64-apple-ios
x86_64-apple-darwin
wasm64-unknown-unknown
wasm32-wasi
wasm32-unknown-unknown
wasm32-unknown-emscripten
thumbv8m.main-none-eabihf
thumbv8m.main-none-eabi
thumbv8m.base-none-eabi
thumbv7neon-unknown-linux-musleabihf
thumbv7neon-unknown-linux-gnueabihf
thumbv7neon-linux-androideabi
thumbv7m-none-eabi
thumbv7em-none-eabihf
thumbv7em-none-eabi
thumbv7a-uwp-windows-msvc
thumbv7a-pc-windows-msvc
thumbv6m-none-eabi
thumbv4t-none-eabi
sparcv9-sun-solaris
sparc64-unknown-openbsd
sparc64-unknown-netbsd
sparc64-unknown-linux-gnu
sparc-unknown-linux-gnu
s390x-unknown-linux-musl
s390x-unknown-linux-gnu
riscv64imac-unknown-none-elf
riscv64gc-unknown-none-elf
riscv64gc-unknown-linux-musl
riscv64gc-unknown-linux-gnu
riscv64gc-unknown-freebsd
riscv32imc-unknown-none-elf
riscv32imc-esp-espidf
riscv32imac-unknown-none-elf
riscv32im-unknown-none-elf
riscv32i-unknown-none-elf
riscv32gc-unknown-linux-musl
riscv32gc-unknown-linux-gnu
powerpc64le-unknown-linux-musl
powerpc64le-unknown-linux-gnu
powerpc64le-unknown-freebsd
powerpc64-wrs-vxworks
powerpc64-unknown-linux-musl
powerpc64-unknown-linux-gnu
powerpc64-unknown-freebsd
powerpc-wrs-vxworks-spe
powerpc-wrs-vxworks
powerpc-unknown-openbsd
powerpc-unknown-netbsd
powerpc-unknown-linux-musl
powerpc-unknown-linux-gnuspe
powerpc-unknown-linux-gnu
powerpc-unknown-freebsd
nvptx64-nvidia-cuda
msp430-none-elf
mipsisa64r6el-unknown-linux-gnuabi64
mipsisa64r6-unknown-linux-gnuabi64
mipsisa32r6el-unknown-linux-gnu
mipsisa32r6-unknown-linux-gnu
mipsel-unknown-none
mipsel-unknown-linux-uclibc
mipsel-unknown-linux-musl
mipsel-unknown-linux-gnu
mipsel-sony-psp
mips64el-unknown-linux-muslabi64
mips64el-unknown-linux-gnuabi64
mips64-unknown-linux-muslabi64
mips64-unknown-linux-gnuabi64
mips64-openwrt-linux-musl
mips-unknown-linux-uclibc
mips-unknown-linux-musl
mips-unknown-linux-gnu
m68k-unknown-linux-gnu
i686-wrs-vxworks
i686-uwp-windows-msvc
i686-uwp-windows-gnu
i686-unknown-uefi
i686-unknown-openbsd
i686-unknown-netbsd
i686-unknown-linux-musl
i686-unknown-linux-gnu
i686-unknown-haiku
i686-unknown-freebsd
i686-pc-windows-msvc
i686-pc-windows-gnu
i686-linux-android
i686-apple-darwin
i586-unknown-linux-musl
i586-unknown-linux-gnu
i586-pc-windows-msvc
i386-apple-ios
hexagon-unknown-linux-musl
bpfel-unknown-none
bpfeb-unknown-none
avr-unknown-gnu-atmega328
asmjs-unknown-emscripten
armv7s-apple-ios
armv7r-none-eabihf
armv7r-none-eabi
armv7a-none-eabihf
armv7a-none-eabi
armv7a-kmc-solid_asp3-eabihf
armv7a-kmc-solid_asp3-eabi
armv7-wrs-vxworks-eabihf
armv7-unknown-netbsd-eabihf
armv7-unknown-linux-uclibceabihf
armv7-unknown-linux-uclibceabi
armv7-unknown-linux-musleabihf
armv7-unknown-linux-musleabi
armv7-unknown-linux-gnueabihf
armv7-unknown-linux-gnueabi
armv7-unknown-freebsd
armv7-linux-androideabi
armv7-apple-ios
armv6k-nintendo-3ds
armv6-unknown-netbsd-eabihf
armv6-unknown-freebsd
armv5te-unknown-linux-uclibceabi
armv5te-unknown-linux-musleabi
armv5te-unknown-linux-gnueabi
armv4t-unknown-linux-gnueabi
armebv7r-none-eabihf
armebv7r-none-eabi
arm-unknown-linux-musleabihf
arm-unknown-linux-musleabi
arm-unknown-linux-gnueabihf
arm-unknown-linux-gnueabi
arm-linux-androideabi
aarch64_be-unknown-linux-gnu_ilp32
aarch64_be-unknown-linux-gnu
aarch64-wrs-vxworks
aarch64-uwp-windows-msvc
aarch64-unknown-uefi
aarch64-unknown-redox
aarch64-unknown-openbsd
aarch64-unknown-none-softfloat
aarch64-unknown-none
aarch64-unknown-netbsd
aarch64-unknown-linux-musl
aarch64-unknown-linux-gnu_ilp32
aarch64-unknown-linux-gnu
aarch64-unknown-hermit
aarch64-unknown-freebsd
aarch64-pc-windows-msvc
aarch64-linux-android
aarch64-kmc-solid_asp3
aarch64-fuchsia
aarch64-apple-tvos
aarch64-apple-ios-sim
aarch64-apple-ios-macabi
aarch64-apple-ios
aarch64-apple-darwin
```

### Zig

Zig also has a nice list:

```sh
zig targets | jq -r '.libc[]' | sort -r
```

```txt
x86_64-windows-gnu
x86_64-macos-none
x86_64-macos-none
x86_64-macos-none
x86_64-linux-musl
x86_64-linux-gnux32
x86_64-linux-gnu
x86-windows-gnu
x86-linux-musl
x86-linux-gnu
wasm32-wasi-musl
wasm32-freestanding-musl
thumb-linux-musleabihf
thumb-linux-musleabi
thumb-linux-gnueabihf
thumb-linux-gnueabi
sparc64-linux-gnu
sparc-linux-gnu
s390x-linux-musl
s390x-linux-gnu
riscv64-linux-musl
riscv64-linux-gnu
powerpc64le-linux-musl
powerpc64le-linux-gnu
powerpc64-linux-musl
powerpc64-linux-gnu
powerpc-linux-musl
powerpc-linux-gnueabihf
powerpc-linux-gnueabi
mipsel-linux-musl
mipsel-linux-gnueabihf
mipsel-linux-gnueabi
mips64el-linux-musl
mips64el-linux-gnuabin32
mips64el-linux-gnuabi64
mips64-linux-musl
mips64-linux-gnuabin32
mips64-linux-gnuabi64
mips-linux-musl
mips-linux-gnueabihf
mips-linux-gnueabi
m68k-linux-musl
m68k-linux-gnu
csky-linux-gnueabihf
csky-linux-gnueabi
armeb-windows-gnu
armeb-linux-musleabihf
armeb-linux-musleabi
armeb-linux-gnueabihf
armeb-linux-gnueabi
arm-windows-gnu
arm-linux-musleabihf
arm-linux-musleabi
arm-linux-gnueabihf
arm-linux-gnueabi
aarch64_be-windows-gnu
aarch64_be-linux-musl
aarch64_be-linux-gnu
aarch64-windows-gnu
aarch64-macos-none
aarch64-macos-none
aarch64-macos-none
aarch64-linux-musl
aarch64-linux-gnu
```