### PR TITLE
Fix broken short rDNS names 

### DIFF
--- a/src/parsley.cpp
+++ b/src/parsley.cpp
@@ -3499,15 +3499,15 @@ AtomicInfo *APar_reverseDNS_atom_Init(const char *rDNS_atom_name,
     APar_atom_Binary_Put(
         &parsedAtoms[rDNS_mean_atom], rDNS_domain, domain_len, 0);
 
-    uint32_t name_len = strlen(rDNS_atom_name);
     short rDNS_name_atom = APar_InterjectNewAtom("name",
                                                  CHILD_ATOM,
                                                  VERSIONED_ATOM,
-                                                 name_len,
+                                                 12,
                                                  AtomFlags_Data_Binary,
                                                  0,
                                                  ilst_atom->AtomicLevel + 2,
                                                  rDNS_mean_atom);
+    uint32_t name_len = strlen(rDNS_atom_name);
     parsedAtoms[rDNS_name_atom].ReverseDNSname =
         (char *)calloc(1, sizeof(char) * 101);
     memcpy(

--- a/src/parsley.cpp
+++ b/src/parsley.cpp
@@ -2388,10 +2388,8 @@ short APar_InterjectNewAtom(const char *atom_name,
 
   new_atom->AtomicData = (char *)calloc(
       1,
-      sizeof(char) * (atom_length > 16
-                          ? atom_length
-                          : 16)); // puts a hard limit on the length of
-                                  // strings (the spec doesn't)
+      sizeof(char) * MAXDATA_PAYLOAD + 1); // puts a hard limit on the length of
+                                           // strings (the spec doesn't)
 
   new_atom->ID32_TagInfo = NULL;
 


### PR DESCRIPTION
This reverts commit d86a31a099c65cfd4a122fec82ba0f5c3c6954c0, restoring the initial allocation of the name atom to 12 bytes, which must be the case, given the way `AtomicLength` is treated. See https://github.com/wez/atomicparsley/issues/66#issuecomment-1932991333 for why.

Additionally, allocate the `AtomicData` buffer to use a MAXDATA_PAYLOAD-sized buffer. This accommodates longer names that were causing problems in #44. Those crashes were happening because of heap corruption due to writing past the end of the 16-byte buffer.