### PR TITLE
Remove `$` from brew install command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ setting metadata into MPEG-4 files, in particular, iTunes-style metadata.
 AtomicParsley is also available for brew users and can be installed by executing this command in a terminal:
 
 ```
-$ brew install atomicparsley
+brew install atomicparsley
 ````
 
 Note that the version available in brew may lag behind the latest version of the code in this repo.


### PR DESCRIPTION
Fix formatting for the brew install command in README to remove `$` to make it easier to copy/paste into terminal.